### PR TITLE
Add pgadmin4 service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,5 +31,20 @@ services:
     ports:
       - '5000:5000'
     command: 'npm run dev'
+  pgadmin:
+    container_name: pgadmin4_container
+    image: dpage/pgadmin4
+    depends_on:
+      - database
+    restart: always
+    environment:
+      PGADMIN_DEFAULT_EMAIL: user@domain.com
+      PGADMIN_DEFAULT_PASSWORD: SuperSecret
+      PGADMIN_CONFIG_SERVER_MODE: "False"
+      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"
+    ports:
+      - "5050:80"
+    volumes:
+      - ./pgadmin4/servers.json:/pgadmin4/servers.json
 volumes:
   database-data: # named volumes can be managed easier using docker-compose

--- a/pgadmin4/servers.json
+++ b/pgadmin4/servers.json
@@ -1,0 +1,13 @@
+{
+  "Servers": {
+    "1": {
+      "Name": "Sequel Mart",
+      "Group": "Servers",
+      "Port": 5432,
+      "Username": "postgres",
+      "Host": "database",
+      "SSLMode": "prefer",
+      "MaintenanceDB": "postgres"
+    }
+  }
+}


### PR DESCRIPTION
Exposes pgadmin4 on port 5050. This is running in desktop mode, so that pgadmin4 login credentials are not required. I believe this is okay, because it will only be available from the local host. It should not be run in desktop mode when it is deployed to a web server.

See [Container Deployment docs](https://www.pgadmin.org/docs/pgadmin4/development/container_deployment.html)

pgadmin4 is configured with the server connection, but I’ve not been successful supplying the password, so this must be entered manually. See `database.env` for the password.