### PR TITLE
Fix #8 by removing postgres port map

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       - database.env # configure postgres
     volumes:
       - database-data:/var/lib/postgresql/data/ # persist data even if container shuts down
-    ports:
-      - "5432:5432"
   populate-database:
     profiles:
       - initialise


### PR DESCRIPTION
We don’t need to expose the postgres port on the host. The containers communicate via their own ports on the bridge network. Exposing the postgres port on `5432` can lead to port clashes with existing postgres instances. If we want to expose postgres, we should do it on something like port `54321`, *but* we don’t need to change the connect strings etc elsewhere as they still communicate via `5432` on the bridge network.

It would be good for someone else to verify that this still works before merging.