### PR TITLE
Remove noise from docker console

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       PGADMIN_DEFAULT_PASSWORD: SuperSecret
       PGADMIN_CONFIG_SERVER_MODE: "False"
       PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"
+      GUNICORN_ACCESS_LOGFILE: /dev/null
     ports:
       - "5050:80"
     volumes:


### PR DESCRIPTION
Send pgadmin access logs to /dev/null as we don’t care about them. See `GUNICORN_ACCESS_LOGFILE` in [environment variable docs](https://www.pgadmin.org/docs/pgadmin4/latest/container_deployment.html#environment-variables) for info.

Tested on my system, but please verify this works before merging.